### PR TITLE
refactor: remove unused registerPayment function from payments service

### DIFF
--- a/src/services/payments.js
+++ b/src/services/payments.js
@@ -87,21 +87,3 @@ export async function registerPayment({
     throw new Error('Error registering the payment',error);
   }
 }
-
-export async function registerPayment({planId,clinicId}) {
-  const paymentData = {planId,clinicId};
-
-  try {
-    const response = await client.post('/payments', paymentData);
-    const { data } = response;
-
-    if (data.url) {
-      window.location.href = data.url; 
-    } else {
-      console.error('No se recibió una URL para redirigir');
-    }
-  } catch (error) {
-    console.error('Error al registrar el pago:', error);
-    throw new Error('No se pudo registrar el pago');
-  }
-}


### PR DESCRIPTION
This pull request removes the `registerPayment` function from the `src/services/payments.js` file. The function was responsible for sending payment data to the server and handling the response, including redirecting to a URL if provided.

Key change:

* [`src/services/payments.js`](diffhunk://#diff-5520543a7cbc1eff93101ca5d26c9100e5b17ac22bc33cf5f195cbafd8571d42L90-L107): Removed the `registerPayment` function, which handled payment registration by sending data to the server and managing the response.